### PR TITLE
Renamed arguments of OBJECT operations

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2949,20 +2949,20 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   @Override
-  public Long objectRefcount(final String string) {
-    client.objectRefcount(string);
+  public Long objectRefcount(String key) {
+    client.objectRefcount(key);
     return client.getIntegerReply();
   }
 
   @Override
-  public String objectEncoding(final String string) {
-    client.objectEncoding(string);
+  public String objectEncoding(String key) {
+    client.objectEncoding(key);
     return client.getBulkReply();
   }
 
   @Override
-  public Long objectIdletime(final String string) {
-    client.objectIdletime(string);
+  public Long objectIdletime(String key) {
+    client.objectIdletime(key);
     return client.getIntegerReply();
   }
 

--- a/src/main/java/redis/clients/jedis/commands/AdvancedJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/AdvancedJedisCommands.java
@@ -17,9 +17,9 @@ public interface AdvancedJedisCommands {
 
   List<Slowlog> slowlogGet(long entries);
 
-  Long objectRefcount(String string);
+  Long objectRefcount(String key);
 
-  String objectEncoding(String string);
+  String objectEncoding(String key);
 
-  Long objectIdletime(String string);
+  Long objectIdletime(String key);
 }


### PR DESCRIPTION
Parameters of OBJECT operations now have name define in Redis documentation (https://redis.io/commands/object).

Also similar names are used in AdvancedBinaryJedisCommands and related implementation.