### PR TITLE
ClusterCommands interface is implemented in BinaryJedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -34,7 +34,8 @@ import redis.clients.util.JedisURIHelper;
 import redis.clients.util.SafeEncoder;
 
 public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKeyBinaryCommands,
-    AdvancedBinaryJedisCommands, BinaryScriptingCommands, Closeable {
+    AdvancedBinaryJedisCommands, BinaryScriptingCommands, ClusterCommands, Closeable {
+
   protected Client client = null;
   protected Transaction transaction = null;
   protected Pipeline pipeline = null;
@@ -3776,4 +3777,151 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     client.hstrlen(key, field);
     return client.getIntegerReply();
   }
+
+  @Override
+  public String clusterNodes() {
+    checkIsInMultiOrPipeline();
+    client.clusterNodes();
+    return client.getBulkReply();
+  }
+
+  @Override
+  public String clusterMeet(final String ip, final int port) {
+    checkIsInMultiOrPipeline();
+    client.clusterMeet(ip, port);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterReset(final BinaryJedisCluster.Reset resetType) {
+    checkIsInMultiOrPipeline();
+    client.clusterReset(resetType);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterAddSlots(final int... slots) {
+    checkIsInMultiOrPipeline();
+    client.clusterAddSlots(slots);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterDelSlots(final int... slots) {
+    checkIsInMultiOrPipeline();
+    client.clusterDelSlots(slots);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterInfo() {
+    checkIsInMultiOrPipeline();
+    client.clusterInfo();
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public List<String> clusterGetKeysInSlot(final int slot, final int count) {
+    checkIsInMultiOrPipeline();
+    client.clusterGetKeysInSlot(slot, count);
+    return client.getMultiBulkReply();
+  }
+
+  @Override
+  public String clusterSetSlotNode(final int slot, final String nodeId) {
+    checkIsInMultiOrPipeline();
+    client.clusterSetSlotNode(slot, nodeId);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterSetSlotMigrating(final int slot, final String nodeId) {
+    checkIsInMultiOrPipeline();
+    client.clusterSetSlotMigrating(slot, nodeId);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterSetSlotImporting(final int slot, final String nodeId) {
+    checkIsInMultiOrPipeline();
+    client.clusterSetSlotImporting(slot, nodeId);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterSetSlotStable(final int slot) {
+    checkIsInMultiOrPipeline();
+    client.clusterSetSlotStable(slot);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterForget(final String nodeId) {
+    checkIsInMultiOrPipeline();
+    client.clusterForget(nodeId);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterFlushSlots() {
+    checkIsInMultiOrPipeline();
+    client.clusterFlushSlots();
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public Long clusterKeySlot(final String key) {
+    checkIsInMultiOrPipeline();
+    client.clusterKeySlot(key);
+    return client.getIntegerReply();
+  }
+
+  @Override
+  public Long clusterCountKeysInSlot(final int slot) {
+    checkIsInMultiOrPipeline();
+    client.clusterCountKeysInSlot(slot);
+    return client.getIntegerReply();
+  }
+
+  @Override
+  public String clusterSaveConfig() {
+    checkIsInMultiOrPipeline();
+    client.clusterSaveConfig();
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public String clusterReplicate(final String nodeId) {
+    checkIsInMultiOrPipeline();
+    client.clusterReplicate(nodeId);
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public List<String> clusterSlaves(final String nodeId) {
+    checkIsInMultiOrPipeline();
+    client.clusterSlaves(nodeId);
+    return client.getMultiBulkReply();
+  }
+
+  @Override
+  public String clusterFailover() {
+    checkIsInMultiOrPipeline();
+    client.clusterFailover();
+    return client.getStatusCodeReply();
+  }
+
+  @Override
+  public List<Object> clusterSlots() {
+    checkIsInMultiOrPipeline();
+    client.clusterSlots();
+    return client.getObjectMultiBulkReply();
+  }
+
+  @Override
+  public String readonly() {
+    client.readonly();
+    return client.getStatusCodeReply();
+  }
+
 }

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -7,6 +7,7 @@ import redis.clients.jedis.params.geo.GeoRadiusParam;
 import redis.clients.jedis.params.set.SetParams;
 import redis.clients.jedis.params.sortedset.ZAddParams;
 import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.util.JedisClusterHashTagUtil;
 import redis.clients.util.KeyMergeUtil;
 import redis.clients.util.SafeEncoder;
 
@@ -17,10 +18,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import redis.clients.util.JedisClusterHashTagUtil;
 
 public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     MultiKeyBinaryJedisClusterCommands, JedisClusterBinaryScriptingCommands, Closeable {
+
+  public static enum Reset {
+    SOFT, HARD
+  }
 
   public static final short HASHSLOTS = 16384;
   protected static final int DEFAULT_TIMEOUT = 2000;

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -12,7 +12,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
-import redis.clients.jedis.JedisCluster.Reset;
+import redis.clients.jedis.BinaryJedisCluster.Reset;
 import redis.clients.jedis.commands.Commands;
 import redis.clients.jedis.params.geo.GeoRadiusParam;
 import redis.clients.jedis.params.set.SetParams;

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -16,10 +16,7 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
-import redis.clients.jedis.JedisCluster.Reset;
 import redis.clients.jedis.commands.AdvancedJedisCommands;
-import redis.clients.jedis.commands.BasicCommands;
-import redis.clients.jedis.commands.ClusterCommands;
 import redis.clients.jedis.commands.JedisCommands;
 import redis.clients.jedis.commands.ModuleCommands;
 import redis.clients.jedis.commands.MultiKeyCommands;
@@ -33,7 +30,7 @@ import redis.clients.util.SafeEncoder;
 import redis.clients.util.Slowlog;
 
 public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommands,
-    AdvancedJedisCommands, ScriptingCommands, BasicCommands, ClusterCommands, SentinelCommands, ModuleCommands {
+    AdvancedJedisCommands, ScriptingCommands, SentinelCommands, ModuleCommands {
 
   protected JedisPoolAbstract dataSource = null;
 
@@ -3271,152 +3268,6 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
           .encode(iterator.next()))));
     }
     return new ScanResult<Tuple>(newcursor, results);
-  }
-
-  @Override
-  public String clusterNodes() {
-    checkIsInMultiOrPipeline();
-    client.clusterNodes();
-    return client.getBulkReply();
-  }
-
-  @Override
-  public String readonly() {
-    client.readonly();
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterMeet(final String ip, final int port) {
-    checkIsInMultiOrPipeline();
-    client.clusterMeet(ip, port);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterReset(final Reset resetType) {
-    checkIsInMultiOrPipeline();
-    client.clusterReset(resetType);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterAddSlots(final int... slots) {
-    checkIsInMultiOrPipeline();
-    client.clusterAddSlots(slots);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterDelSlots(final int... slots) {
-    checkIsInMultiOrPipeline();
-    client.clusterDelSlots(slots);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterInfo() {
-    checkIsInMultiOrPipeline();
-    client.clusterInfo();
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public List<String> clusterGetKeysInSlot(final int slot, final int count) {
-    checkIsInMultiOrPipeline();
-    client.clusterGetKeysInSlot(slot, count);
-    return client.getMultiBulkReply();
-  }
-
-  @Override
-  public String clusterSetSlotNode(final int slot, final String nodeId) {
-    checkIsInMultiOrPipeline();
-    client.clusterSetSlotNode(slot, nodeId);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterSetSlotMigrating(final int slot, final String nodeId) {
-    checkIsInMultiOrPipeline();
-    client.clusterSetSlotMigrating(slot, nodeId);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterSetSlotImporting(final int slot, final String nodeId) {
-    checkIsInMultiOrPipeline();
-    client.clusterSetSlotImporting(slot, nodeId);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterSetSlotStable(final int slot) {
-    checkIsInMultiOrPipeline();
-    client.clusterSetSlotStable(slot);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterForget(final String nodeId) {
-    checkIsInMultiOrPipeline();
-    client.clusterForget(nodeId);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterFlushSlots() {
-    checkIsInMultiOrPipeline();
-    client.clusterFlushSlots();
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public Long clusterKeySlot(final String key) {
-    checkIsInMultiOrPipeline();
-    client.clusterKeySlot(key);
-    return client.getIntegerReply();
-  }
-
-  @Override
-  public Long clusterCountKeysInSlot(final int slot) {
-    checkIsInMultiOrPipeline();
-    client.clusterCountKeysInSlot(slot);
-    return client.getIntegerReply();
-  }
-
-  @Override
-  public String clusterSaveConfig() {
-    checkIsInMultiOrPipeline();
-    client.clusterSaveConfig();
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public String clusterReplicate(final String nodeId) {
-    checkIsInMultiOrPipeline();
-    client.clusterReplicate(nodeId);
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public List<String> clusterSlaves(final String nodeId) {
-    checkIsInMultiOrPipeline();
-    client.clusterSlaves(nodeId);
-    return client.getMultiBulkReply();
-  }
-
-  @Override
-  public String clusterFailover() {
-    checkIsInMultiOrPipeline();
-    client.clusterFailover();
-    return client.getStatusCodeReply();
-  }
-
-  @Override
-  public List<Object> clusterSlots() {
-    checkIsInMultiOrPipeline();
-    client.clusterSlots();
-    return client.getObjectMultiBulkReply();
   }
 
   public String asking() {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -23,9 +23,6 @@ import redis.clients.util.SafeEncoder;
 
 public class JedisCluster extends BinaryJedisCluster implements JedisClusterCommands,
     MultiKeyJedisClusterCommands, JedisClusterScriptingCommands {
-  public static enum Reset {
-    SOFT, HARD
-  }
 
   public JedisCluster(HostAndPort node) {
 	this(Collections.singleton(node), DEFAULT_TIMEOUT);

--- a/src/main/java/redis/clients/jedis/commands/ClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ClusterCommands.java
@@ -2,7 +2,7 @@ package redis.clients.jedis.commands;
 
 import java.util.List;
 
-import redis.clients.jedis.JedisCluster.Reset;
+import redis.clients.jedis.BinaryJedisCluster.Reset;
 
 public interface ClusterCommands {
   String clusterNodes();

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -31,10 +31,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import redis.clients.jedis.BinaryJedisCluster.Reset;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.JedisCluster.Reset;
 import redis.clients.jedis.JedisClusterInfoCache;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisCluster.Reset;
+import redis.clients.jedis.BinaryJedisCluster.Reset;
 import redis.clients.jedis.tests.HostAndPortUtil;
 import redis.clients.jedis.tests.utils.JedisClusterTestUtil;
 


### PR DESCRIPTION
`ClusterCommands` methods are accessible from only `Jedis` but not `BinaryJedis`. This change would allow us to access those methods from both classes.