### PR TITLE
Null response of Redis is kept unaltered

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -73,7 +72,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public List<String> build(Object data) {
       if (null == data) {
-        return Collections.emptyList();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
       final ArrayList<String> result = new ArrayList<String>(l.size());
@@ -138,7 +137,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<String> build(Object data) {
       if (null == data) {
-        return Collections.emptySet();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<String> result = new HashSet<String>(l.size(), 1);
@@ -163,7 +162,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public List<byte[]> build(Object data) {
       if (null == data) {
-        return Collections.emptyList();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
 
@@ -180,7 +179,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<byte[]> build(Object data) {
       if (null == data) {
-        return Collections.emptySet();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<byte[]> result = new LinkedHashSet<byte[]>(l);
@@ -223,7 +222,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<String> build(Object data) {
       if (null == data) {
-        return Collections.emptySet();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<String> result = new LinkedHashSet<String>(l.size(), 1);
@@ -248,7 +247,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<Tuple> build(Object data) {
       if (null == data) {
-        return Collections.emptySet();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size()/2, 1);
@@ -271,7 +270,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<Tuple> build(Object data) {
       if (null == data) {
-        return Collections.emptySet();
+        return null;
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size()/2, 1);
@@ -349,7 +348,7 @@ public final class BuilderFactory {
     @Override
     public List<GeoCoordinate> build(Object data) {
       if (null == data) {
-        return Collections.emptyList();
+        return null;
       }
       return interpretGeoposResult((List<Object>) data);
     }
@@ -379,7 +378,7 @@ public final class BuilderFactory {
     @Override
     public List<GeoRadiusResponse> build(Object data) {
       if (data == null) {
-        return Collections.emptyList();
+        return null;
       } else {
         List<Object> objectList = (List<Object>) data;
 
@@ -439,7 +438,7 @@ public final class BuilderFactory {
     @Override
     public List<Module> build(Object data) {
       if (data == null) {
-        return Collections.emptyList();
+        return null;
       } else {
         List<List<Object>> objectList = (List<List<Object>>) data;
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1236,7 +1236,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.spop(key, count);
     final List<String> members = client.getMultiBulkReply();
     if (members == null) {
-      return Collections.emptySet();
+      return null;
     }
     return SetFromList.of(members);
   }

--- a/src/test/java/redis/clients/jedis/tests/commands/ListCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ListCommandsTest.java
@@ -426,9 +426,6 @@ public class ListCommandsTest extends JedisCommandTestBase {
   @Test
   public void blpop() throws InterruptedException {
     List<String> result = jedis.blpop(1, "foo");
-    if(result.isEmpty()){
-      result = null;
-    }
     assertNull(result);
 
     jedis.lpush("foo", "bar");
@@ -453,9 +450,6 @@ public class ListCommandsTest extends JedisCommandTestBase {
   @Test
   public void brpop() throws InterruptedException {
     List<String> result = jedis.brpop(1, "foo");
-    if(result.isEmpty()){
-      result = null;
-    }
     assertNull(result);
 
     jedis.lpush("foo", "bar");


### PR DESCRIPTION
If Redis's response is null, user should get that. Changing it to empty collection hides the significance of null.