### PR TITLE
Modified Connection class

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -263,11 +263,11 @@ public class Connection implements Closeable {
 
   @SuppressWarnings("unchecked")
   public List<Object> getRawObjectMultiBulkReply() {
+    flush();
     return (List<Object>) readProtocolWithCheckingBroken();
   }
 
   public List<Object> getObjectMultiBulkReply() {
-    flush();
     return getRawObjectMultiBulkReply();
   }
 

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -233,22 +233,12 @@ public class Connection implements Closeable {
   }
 
   public String getStatusCodeReply() {
-    flush();
-    final byte[] resp = (byte[]) readProtocolWithCheckingBroken();
-    if (null == resp) {
-      return null;
-    } else {
-      return SafeEncoder.encode(resp);
-    }
+    return getBulkReply();
   }
 
   public String getBulkReply() {
     final byte[] result = getBinaryBulkReply();
-    if (null != result) {
-      return SafeEncoder.encode(result);
-    } else {
-      return null;
-    }
+    return (null != result) ? SafeEncoder.encode(result) : null;
   }
 
   public byte[] getBinaryBulkReply() {


### PR DESCRIPTION
1. `getStatusCodeReply()` is exact same of `getBinaryBulkReply()` + `getBulkReply()`. Removed redundant codes and reused codes there.

2. `flush()` was missing in `getRawObjectMultiBulkReply()`. It is added there. Also `getObjectMultiBulkReply()` just call `getRawObjectMultiBulkReply()`. So `flush()` is removed from `getObjectMultiBulkReply()` as it is already added in `getRawObjectMultiBulkReply()`.