### PR TITLE
Using available BinaryClient methods for zrange operations from BinaryJedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -621,7 +621,6 @@ public class BinaryClient extends Connection {
   }
 
   public void zcount(final byte[] key, final double min, final double max) {
-
     sendCommand(ZCOUNT, key, toByteArray(min), toByteArray(max));
   }
 
@@ -629,12 +628,7 @@ public class BinaryClient extends Connection {
     sendCommand(ZCOUNT, key, min, max);
   }
 
-  public void zcount(final byte[] key, final String min, final String max) {
-    sendCommand(ZCOUNT, key, min.getBytes(), max.getBytes());
-  }
-
   public void zrangeByScore(final byte[] key, final double min, final double max) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max));
   }
 
@@ -642,12 +636,7 @@ public class BinaryClient extends Connection {
     sendCommand(ZRANGEBYSCORE, key, min, max);
   }
 
-  public void zrangeByScore(final byte[] key, final String min, final String max) {
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes());
-  }
-
   public void zrevrangeByScore(final byte[] key, final double max, final double min) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min));
   }
 
@@ -655,82 +644,36 @@ public class BinaryClient extends Connection {
     sendCommand(ZREVRANGEBYSCORE, key, max, min);
   }
 
-  public void zrevrangeByScore(final byte[] key, final String max, final String min) {
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes());
-  }
-
   public void zrangeByScore(final byte[] key, final double min, final double max, final int offset,
       final int count) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max), LIMIT.raw, toByteArray(offset),
-      toByteArray(count));
-  }
-
-  public void zrangeByScore(final byte[] key, final String min, final String max, final int offset,
-      final int count) {
-
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes(), LIMIT.raw, toByteArray(offset),
       toByteArray(count));
   }
 
   public void zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min), LIMIT.raw, toByteArray(offset),
       toByteArray(count));
   }
 
-  public void zrevrangeByScore(final byte[] key, final String max, final String min,
-      final int offset, final int count) {
-
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes(), LIMIT.raw,
-      toByteArray(offset), toByteArray(count));
-  }
-
   public void zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max), WITHSCORES.raw);
   }
 
-  public void zrangeByScoreWithScores(final byte[] key, final String min, final String max) {
-
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes(), WITHSCORES.raw);
-  }
-
   public void zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min), WITHSCORES.raw);
-  }
-
-  public void zrevrangeByScoreWithScores(final byte[] key, final String max, final String min) {
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes(), WITHSCORES.raw);
   }
 
   public void zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max), LIMIT.raw, toByteArray(offset),
-      toByteArray(count), WITHSCORES.raw);
-  }
-
-  public void zrangeByScoreWithScores(final byte[] key, final String min, final String max,
-      final int offset, final int count) {
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes(), LIMIT.raw, toByteArray(offset),
       toByteArray(count), WITHSCORES.raw);
   }
 
   public void zrevrangeByScoreWithScores(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min), LIMIT.raw, toByteArray(offset),
       toByteArray(count), WITHSCORES.raw);
-  }
-
-  public void zrevrangeByScoreWithScores(final byte[] key, final String max, final String min,
-      final int offset, final int count) {
-
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes(), LIMIT.raw,
-      toByteArray(offset), toByteArray(count), WITHSCORES.raw);
   }
 
   public void zrangeByScore(final byte[] key, final byte[] min, final byte[] max, final int offset,
@@ -773,10 +716,6 @@ public class BinaryClient extends Connection {
 
   public void zremrangeByScore(final byte[] key, final byte[] start, final byte[] end) {
     sendCommand(ZREMRANGEBYSCORE, key, start, end);
-  }
-
-  public void zremrangeByScore(final byte[] key, final String start, final String end) {
-    sendCommand(ZREMRANGEBYSCORE, key, start.getBytes(), end.getBytes());
   }
 
   public void zunionstore(final byte[] dstkey, final byte[]... sets) {

--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -767,6 +767,10 @@ public class BinaryClient extends Connection {
     sendCommand(ZREMRANGEBYRANK, key, toByteArray(start), toByteArray(end));
   }
 
+  public void zremrangeByScore(final byte[] key, final double start, final double end) {
+    sendCommand(ZREMRANGEBYSCORE, key, toByteArray(start), toByteArray(end));
+  }
+
   public void zremrangeByScore(final byte[] key, final byte[] start, final byte[] end) {
     sendCommand(ZREMRANGEBYSCORE, key, start, end);
   }

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2333,7 +2333,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max) {
-    return zrangeByScore(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zrangeByScore(key, min, max);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2393,7 +2395,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return zrangeByScore(key, toByteArray(min), toByteArray(max), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrangeByScore(key, min, max, offset, count);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2453,7 +2457,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-    return zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zrangeByScoreWithScores(key, min, max);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2513,7 +2519,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrangeByScoreWithScores(key, min, max, offset, count);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2539,7 +2547,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min) {
-    return zrevrangeByScore(key, toByteArray(max), toByteArray(min));
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScore(key, max, min);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2552,7 +2562,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-    return zrevrangeByScore(key, toByteArray(max), toByteArray(min), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScore(key, max, min, offset, count);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2565,13 +2577,17 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-    return zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min));
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScoreWithScores(key, max, min);
+    return getBinaryTupledSet();
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max,
       final double min, final int offset, final int count) {
-    return zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScoreWithScores(key, max, min, offset, count);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2621,7 +2637,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Long zremrangeByScore(final byte[] key, final double start, final double end) {
-    return zremrangeByScore(key, toByteArray(start), toByteArray(end));
+    checkIsInMultiOrPipeline();
+    client.zremrangeByScore(key, start, end);
+    return client.getIntegerReply();
   }
 
   @Override


### PR DESCRIPTION
1. Using available `BinaryClient` methods for zrange operations from `BinaryJedis`. Currently, in `BinaryJedis`, those calls are forwarded to similar public methods. But in `Jedis`, similar operations are done other way.

2. Removed `BinaryClient` methods having both `byte[]` and `String` as params. This does not go along with current project design. Moreover, these methods are not used anywhere in this project.