### PR TITLE
Added 'missing' flush in getRawObjectMultiBulkReply

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -273,11 +273,11 @@ public class Connection implements Closeable {
 
   @SuppressWarnings("unchecked")
   public List<Object> getRawObjectMultiBulkReply() {
+    flush();
     return (List<Object>) readProtocolWithCheckingBroken();
   }
 
   public List<Object> getObjectMultiBulkReply() {
-    flush();
     return getRawObjectMultiBulkReply();
   }
 


### PR DESCRIPTION
- Added 'missing' flush in getRawObjectMultiBulkReply
- Removed flush from getObjectMultiBulkReply because it just calls getRawObjectMultiBulkReply and flush is added there.