### PR TITLE
Removed null checking where Redis does not return null - SPOP

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1276,9 +1276,6 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.spop(key, count);
     final List<String> members = client.getMultiBulkReply();
-    if (members == null) {
-      return null;
-    }
     return SetFromList.of(members);
   }
 


### PR DESCRIPTION
SPOP without count option can return null. But with count option it never returns null.