### PR TITLE
Update commons-pool2 to version 2.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
-      <version>2.4.2</version>
+      <version>2.4.3</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/POOL-303 is released.